### PR TITLE
Fix memory access error on backward

### DIFF
--- a/cuda_rasterizer/backward.cu
+++ b/cuda_rasterizer/backward.cu
@@ -491,8 +491,10 @@ renderCUDA(
 			collected_conic_opacity[block.thread_rank()] = conic_opacity[coll_id];
 			for (int i = 0; i < C; i++)
 				collected_colors[i * BLOCK_SIZE + block.thread_rank()] = colors[coll_id * C + i];
-			for (int i = 0; i < F; i++)
-				collected_feature[i * BLOCK_SIZE + block.thread_rank()] = language_feature[coll_id * F + i];
+			if (include_feature) {
+				for (int i = 0; i < F; i++)
+					collected_feature[i * BLOCK_SIZE + block.thread_rank()] = language_feature[coll_id * F + i];
+			}
 		}
 		block.sync();
 


### PR DESCRIPTION
When trained with `include_feature = False`, the rasterizer throws a memory access error on backward pass. Resolves https://github.com/minghanqin/LangSplat/issues/17.

Amazing work by the way!